### PR TITLE
Automatic timestamp columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ message.persisted?
 # => false
 ```
 
+### Timestamp Columns
+
+If any of the columns are named `created_at` or `updated_at`, then they are
+automatically [serialized as Time objects](#motionrecordserialization) and set
+to `Time.now` when the record is created or updated.
+
 MotionRecord::Schema
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ def application(application, didFinishLaunchingWithOptions:launchOptions)
         t.integer :read_at
         t.integer :remote_id
         t.float   :satisfaction, default: 0.0
+        t.timestamps
       end
     end
 

--- a/lib/motion_record/schema/table_definition.rb
+++ b/lib/motion_record/schema/table_definition.rb
@@ -36,6 +36,12 @@ module MotionRecord
         @index_definitions << IndexDefinition.new(@name, columns, options)
       end
 
+      # Add :created_at and :updated_at columns to the table
+      def timestamps
+        self.integer(:created_at)
+        self.integer(:updated_at)
+      end
+
       protected
 
       def add_default_primary_column


### PR DESCRIPTION
- If any of the columns are named `created_at` or `updated_at`, then they are automatically serialized as Time objects and set to `Time.now` when the record is created or updated.
- Added `t.timestamps` helper to define `created_at` and `updated_at` INTEGER columns
